### PR TITLE
Fixing add view

### DIFF
--- a/tests/testthat/test-add_view.R
+++ b/tests/testthat/test-add_view.R
@@ -22,13 +22,6 @@ INSERT INTO persons VALUES
 ;
 ")
 
-# Ensure the registry table exists
-dbExecute(con, "
-CREATE TABLE IF NOT EXISTS _pipeline_registry (
-  pipeline_name TEXT PRIMARY KEY,
-  current_view TEXT
-)
-")
 
 # ---- TESTS ----
 test_that("Pipeline auto-initializes if it does not exist", {
@@ -38,9 +31,9 @@ test_that("Pipeline auto-initializes if it does not exist", {
            base_table = "persons")
 
   # Check registry
-  registry <- dbGetQuery(con, "SELECT * FROM _pipeline_registry WHERE pipeline_name='test_pipeline'")
+  registry <- dbGetQuery(con, "SELECT * FROM _pipeline_registry WHERE pipeline_name = 'test_pipeline'")
   expect_equal(nrow(registry), 1)
-  expect_equal(registry$current_view, "test_pipeline_view_2")
+  expect_equal(registry$current_view, "test_pipeline_view_1")
 
 })
 
@@ -53,12 +46,12 @@ test_that("Adding multiple steps creates versioned views and updates final alias
 
   # Check registry points to latest version
   registry <- dbGetQuery(con, "SELECT current_view FROM _pipeline_registry WHERE pipeline_name='test_pipeline'")
-  expect_equal(registry$current_view, "test_pipeline_view_4")
+  expect_equal(registry$current_view, "test_pipeline_view_3")
 
 })
 
 test_that("Final view returns expected data", {
-  result <- dbGetQuery(con, "SELECT * FROM test_pipeline_view_4 ORDER BY name")
+  result <- dbGetQuery(con, "SELECT * FROM test_pipeline_view_3 ORDER BY name")
 
   # Check that duplicates are removed
   expect_equal(nrow(result), 3)

--- a/tests/testthat/test-clean_missing_values.R
+++ b/tests/testthat/test-clean_missing_values.R
@@ -25,10 +25,10 @@ test_that("VIEW clean_missing_values creates views correctly", {
 
   # Check that PERSONS_view exists
   views <- DBI::dbGetQuery(con, "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW'")
-  expect_true(all(c("PERSONS_T2DMM_view_1","PERSONS_T2DMM_view_2") %in% views$table_name))
+  expect_true(all(c("PERSONS_T2DMM_view_1") %in% views$table_name))
 
   # Check data from the view
-  res <- DBI::dbGetQuery(con, "SELECT * FROM PERSONS_T2DMM_view_2 ORDER BY person_id")
+  res <- DBI::dbGetQuery(con, "SELECT * FROM PERSONS_T2DMM_view_1 ORDER BY person_id")
   expect_equal(res$person_id, c(1, 5)) # Only valid rows remain
 
   DBI::dbDisconnect(con, shutdown = TRUE)

--- a/tests/testthat/test-delete_duplicates_origin.R
+++ b/tests/testthat/test-delete_duplicates_origin.R
@@ -160,7 +160,7 @@ test_that("VIEW: Checking if the function delete the duplicates cases using *", 
     to_view = TRUE
   )
   
-  vx_db <- DBI::dbReadTable(db_con, "VACCINES_T2DMM_view_2")
+  vx_db <- DBI::dbReadTable(db_con, "VACCINES_T2DMM_view_1")
   # The first 10 rows of vx1 are duplicates of vx2
   expect_equal(nrow(vx_db), nrow(vx1))
 
@@ -183,7 +183,7 @@ test_that("VIEW: Checking if the function delete the duplicates cases", {
   )
   
   vx1 <- import_file("dbtest/VACCINES.csv")
-  vx_db <- DBI::dbReadTable(db_con, "VACCINES_T2DMM_view_2")
+  vx_db <- DBI::dbReadTable(db_con, "VACCINES_T2DMM_view_1")
   # The first 10 rows of vx1 are duplicates of vx2
   expect_equal(nrow(vx_db), nrow(vx1))
 })


### PR DESCRIPTION
In this PR I delete the autogeneration of a first view before adding views. Now, if we are adding the first view on a pipeline, this will be the first view.